### PR TITLE
Update pytest_integration.py

### DIFF
--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -215,6 +215,27 @@ class IntegrationTestAPI(DataHandler):
         """
         self.event_log_filter = self.get_event_pred(event, args, severity, time_pred)
 
+    def get_mnemonic(self, item=None):
+        """
+        Get the mnemonic string of the specified dictionary item
+        Args:
+            item: Either dictionary item id (int) or a dictionary item name (str)
+        Returns:
+            Either a mnemonic string or a passing id (int) representing the dictionary item
+        """
+        fsw_dict = self.pipeline.dictionaries.command_name | \
+                   self.pipeline.dictionaries.channel_name | \
+                   self.pipeline.dictionaries.event_name
+
+        if isinstance(item, str):
+            matching = [fsw_dict[name].get_id() for name in fsw_dict.keys() if name.endswith(f".{item}")]
+            if not matching:
+                msg = f"The corresponding mnemonic for {item} wasn't in the dictionary"
+                raise KeyError(msg)
+            return matching[0]
+        else:
+            return item
+
     ######################################################################################
     #   History Functions
     ######################################################################################
@@ -321,6 +342,8 @@ class IntegrationTestAPI(DataHandler):
         Returns:
             The command ID (int)
         """
+        command = self.get_mnemonic(command)
+        
         if isinstance(command, str):
             cmd_dict = self.pipeline.dictionaries.command_name
             if command in cmd_dict:
@@ -537,6 +560,8 @@ class IntegrationTestAPI(DataHandler):
         Returns:
             an instance of telemetry_predicate
         """
+        channel = self.get_mnemonic(channel)
+        
         if isinstance(channel, predicates.telemetry_predicate):
             return channel
 
@@ -758,6 +783,8 @@ class IntegrationTestAPI(DataHandler):
         Returns:
             an instance of event_predicate
         """
+        event = self.get_mnemonic(event)
+        
         if isinstance(event, predicates.event_predicate):
             return event
 

--- a/src/fprime_gds/common/testing_fw/pytest_integration.py
+++ b/src/fprime_gds/common/testing_fw/pytest_integration.py
@@ -39,6 +39,9 @@ def pytest_addoption(parser):
         flags = [flag for flag in flags if flag.startswith("--")]
         parser.addoption(*flags, **specifiers)
 
+    # Add an option to specify the Python configuration file
+    parser.addoption("--config", default="test/int/component_config.py")
+
 
 @pytest.fixture(scope='session')
 def fprime_test_api_session(request):


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  [3213](https://github.com/nasa/fprime/issues/3213)  |
|**_Has Unit Tests (y/n)_**|  N  |
|**_Documentation Included (y/n)_**| Y |

---
## Change Description

A description of the changes contained in the PR.

An enhancement request for a Python tool that takes as input the `instances.fpp` file and creates the test/int directory within a deployment's directory and generate a Python configuration file in that directory. The configuration file will map components to their component instance name (this name is found in the `instances.fpp`); hence, `api.py` has been modified to take dictionary name of command, event, and channel (_instance.name_) without the need to pass in the deployment. In addition, an option to specify the Python configuration file has also been added in `pytest_integration.py`.

## Rationale

A rationale for this change. e.g. fixes bug, or most projects need XYZ feature.

Component instance names can be different across different deployments. As we start developing InT scripts for each component, we'll need to implement them while being deployment agnostic. The scripts will utilize the configuration file to know the component's instance name. This is different than the current approach to hardcode the instance name in the InT script.

## Testing/Review Recommendations

Fill in testing procedures, specific items to focus on for review, or other info to help the team verify these changes are flight-quality.

- Created LedBlinker deployment
- Created a fprime-gds sandbox
- Ran LedBlinker system test with modifications to argument pass to api used on `fprime-fsw-0`

## Future Work

Note any additional work that will be done relating to this issue.
