### PR TITLE
InT to load a deployment specific config file and provide necessary mapping

### DIFF
--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -31,7 +31,7 @@ class IntegrationTestAPI(DataHandler):
 
     NOW = "NOW"
 
-    def __init__(self, pipeline, deployment_config, logpath=None, fsw_order=True):
+    def __init__(self, pipeline, deployment_config=None, logpath=None, fsw_order=True):
         """
         Initializes API: constructs and registers test histories.
         Args:

--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -239,7 +239,7 @@ class IntegrationTestAPI(DataHandler):
         try:
             with open(dictionary, 'r') as file:
                 data = json.load(file)
-            deployment = data['metadata'].get("deploymentName")
+            return data['metadata'].get("deploymentName")
         except FileNotFoundError:
             msg = f"Error: File not found at path: {dictionary}"
             self.__log(msg, TestLogger.YELLOW)
@@ -252,7 +252,6 @@ class IntegrationTestAPI(DataHandler):
             msg = f"An unexpected error occurred: {e} is an unknown key"
             self.__log(msg, TestLogger.YELLOW)
             return None
-        return deployment
 
     def wait_for_dataflow(self, count=1, channels=None, start=None, timeout=120):
         """
@@ -286,6 +285,8 @@ class IntegrationTestAPI(DataHandler):
         """
         if hasattr(self.pipeline, "deployment_config"):
             return self.pipeline.deployment_config
+        else:
+            return None
 
     def load_config_file(self):
         """
@@ -299,6 +300,7 @@ class IntegrationTestAPI(DataHandler):
         try:
             with open(config_file, 'r') as file:
                 result = json.load(file)
+            return result
         except FileNotFoundError:
             msg = f"Error: File not found at path {config_file}"
             self.__log(msg, TestLogger.RED)
@@ -311,15 +313,14 @@ class IntegrationTestAPI(DataHandler):
             msg = f"An unexpected error occurred: {e}"
             self.__log(msg, TestLogger.RED)
             assert False, msg
-        return result
 
-    def getCmdDispName(self, instance=None, name=None):
+    def get_mnemonic(self, comp=None, name=None):
         """
         Get deployment mnemonic of specified item from user-specified deployment
         configuration file.
 
         Args:
-            instance: native component to instance (str), i.e. "<component>.<instance>"
+            comp: qualified name of the component (str), i.e. "<component>.<instance>"
             name: command, channel, or event name (str) [optional]
         Returns:
             deployment mnemonic of specified item (str) or native mnemonic (str) if not found
@@ -328,13 +329,13 @@ class IntegrationTestAPI(DataHandler):
 
         if data:
             try:
-                mnemonic = data[instance]
+                mnemonic = data[comp]
+                return f"{mnemonic}.{name}" if name else f"{mnemonic}"
             except KeyError:
-                self.__log(f"Error: {instance} not found", TestLogger.YELLOW)
-                return f"{instance}.{name}" if name else f"{instance}"
-            return f"{mnemonic}.{name}" if name else f"{mnemonic}"
+                self.__log(f"Error: {comp} not found", TestLogger.YELLOW)
+                return f"{comp}.{name}" if name else f"{comp}"
 
-    def getPrmDbFilename(self):
+    def get_prm_db_path(self) -> str:
         """
         Get file path to parameter db from user-specified deployment configuration file.
 
@@ -345,7 +346,7 @@ class IntegrationTestAPI(DataHandler):
 
         if data:
             try:
-                return data["Svc.PrmDb.filepath"]
+                return data["Svc.PrmDb.filename"]
             except KeyError:
                 return None
 

--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -346,7 +346,13 @@ class IntegrationTestAPI(DataHandler):
 
         if data:
             try:
-                return data["Svc.PrmDb.filename"]
+                filepath = data["Svc.PrmDb.filename"]
+                if filepath.startswith('/'):
+                    return filepath
+                else:
+                    msg = f"Error: {filepath} did not start with a forward slash"
+                    self.__log(msg, TestLogger.RED)
+                    assert False, msg
             except KeyError:
                 return None
 

--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -11,6 +11,7 @@ import signal
 import time
 from pathlib import Path
 import shutil
+import json
 
 from fprime.common.models.serialize.time_type import TimeType
 
@@ -228,11 +229,30 @@ class IntegrationTestAPI(DataHandler):
 
     def get_deployment(self):
         """
-        Get the deployment of the target using the loaded FSW dictionary path
+        Get the deployment of the target using the loaded FSW dictionary.
+
         Returns:
-            The name of the deployment (str)
+            The name of the deployment (str) or None if not found
         """
-        return Path(self.pipeline.dictionary_path).parent.parent.name
+        dictionary = str(self.pipeline.dictionary_path)
+
+        try:
+            with open(dictionary, 'r') as file:
+                data = json.load(file)
+            deployment = data['metadata'].get("deploymentName")
+        except FileNotFoundError:
+            msg = f"Error: File not found at path: {dictionary}"
+            self.__log(msg, TestLogger.YELLOW)
+            return None
+        except json.JSONDecodeError as e:
+            msg = f"Error decoding JSON: {e}"
+            self.__log(msg, TestLogger.YELLOW)
+            return None
+        except Exception as e:
+            msg = f"An unexpected error occurred: {e} is an unknown key"
+            self.__log(msg, TestLogger.YELLOW)
+            return None
+        return deployment
 
     def wait_for_dataflow(self, count=1, channels=None, start=None, timeout=120):
         """
@@ -256,6 +276,78 @@ class IntegrationTestAPI(DataHandler):
             self.__log(msg, TestLogger.RED)
             assert False, msg
         self.remove_telemetry_subhistory(history)
+
+    def get_config_file_path(self):
+        """
+        Accessor for IntegrationTestAPI's deployment configuration file.
+
+        Returns:
+            path to user-specified deployment configuration file (str)
+        """
+        if hasattr(self.pipeline, "deployment_config"):
+            return self.pipeline.deployment_config
+
+    def load_config_file(self):
+        """
+        Load user-specified deployment configuration JSON file.
+
+        Returns:
+            JSON object as a dictionary
+        """
+        config_file = self.get_config_file_path()
+
+        try:
+            with open(config_file, 'r') as file:
+                result = json.load(file)
+        except FileNotFoundError:
+            msg = f"Error: File not found at path {config_file}"
+            self.__log(msg, TestLogger.RED)
+            assert False, msg
+        except json.JSONDecodeError as e:
+            msg = f"Error decoding JSON: {e}"
+            self.__log(msg, TestLogger.RED)
+            assert False, msg
+        except Exception as e:
+            msg = f"An unexpected error occurred: {e}"
+            self.__log(msg, TestLogger.RED)
+            assert False, msg
+        return result
+
+    def getCmdDispName(self, instance=None, name=None):
+        """
+        Get deployment mnemonic of specified item from user-specified deployment
+        configuration file.
+
+        Args:
+            instance: native component to instance (str), i.e. "<component>.<instance>"
+            name: command, channel, or event name (str) [optional]
+        Returns:
+            deployment mnemonic of specified item (str) or native mnemonic (str) if not found
+        """
+        data = self.load_config_file()
+
+        if data:
+            try:
+                mnemonic = data[instance]
+            except KeyError:
+                self.__log(f"Error: {instance} not found", TestLogger.YELLOW)
+                return f"{instance}.{name}" if name else f"{instance}"
+            return f"{mnemonic}.{name}" if name else f"{mnemonic}"
+
+    def getPrmDbFilename(self):
+        """
+        Get file path to parameter db from user-specified deployment configuration file.
+
+        Returns:
+            file path to parameter db (str) or None if not found
+        """
+        data = self.load_config_file()
+
+        if data:
+            try:
+                return data["Svc.PrmDb.filepath"]
+            except KeyError:
+                return None
 
     ######################################################################################
     #   History Functions

--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -31,15 +31,17 @@ class IntegrationTestAPI(DataHandler):
 
     NOW = "NOW"
 
-    def __init__(self, pipeline, logpath=None, fsw_order=True):
+    def __init__(self, pipeline, deployment_config, logpath=None, fsw_order=True):
         """
         Initializes API: constructs and registers test histories.
         Args:
             pipeline: a pipeline object providing access to basic GDS functionality
+            deployment_config: path to deployment configuration file
             logpath: an optional output destination for the api test log
             fsw_order: a flag to determine whether the API histories will maintain FSW time order.
         """
         self.pipeline = pipeline
+        self.deployment_config = deployment_config
 
         # these are owned by the GDS and will not be modified by the test API.
         self.aggregate_command_history = pipeline.histories.commands
@@ -281,10 +283,10 @@ class IntegrationTestAPI(DataHandler):
         Accessor for IntegrationTestAPI's deployment configuration file.
 
         Returns:
-            path to user-specified deployment configuration file (str)
+            path to user-specified deployment configuration file (str) or None if not defined
         """
-        if hasattr(self.pipeline, "deployment_config"):
-            return self.pipeline.deployment_config
+        if self.deployment_config:
+            return self.deployment_config
         else:
             return None
 
@@ -320,7 +322,7 @@ class IntegrationTestAPI(DataHandler):
         configuration file.
 
         Args:
-            comp: qualified name of the component (str), i.e. "<component>.<instance>"
+            comp: qualified name of the component instance (str), i.e. "<component>.<instance>"
             name: command, channel, or event name (str) [optional]
         Returns:
             deployment mnemonic of specified item (str) or native mnemonic (str) if not found
@@ -334,6 +336,8 @@ class IntegrationTestAPI(DataHandler):
             except KeyError:
                 self.__log(f"Error: {comp} not found", TestLogger.YELLOW)
                 return f"{comp}.{name}" if name else f"{comp}"
+        else:
+            return f"{comp}.{name}" if name else f"{comp}"
 
     def get_prm_db_path(self) -> str:
         """
@@ -355,6 +359,8 @@ class IntegrationTestAPI(DataHandler):
                     assert False, msg
             except KeyError:
                 return None
+        else:
+            return None
 
     ######################################################################################
     #   History Functions

--- a/src/fprime_gds/common/testing_fw/pytest_integration.py
+++ b/src/fprime_gds/common/testing_fw/pytest_integration.py
@@ -69,10 +69,6 @@ def pytest_configure(config):
     if config.getoption("--gen-junitxml"):
         config.option.xmlpath = Path(config.getoption("--logs")) / config.getoption("--junit-xml-file")
 
-    # Get the file path to the deployment configuration file
-    if config.getoption("--deployment-config"):
-        deployment_config = config.getoption("--deployment-config")
-
 @pytest.fixture(scope='session')
 def fprime_test_api_session(request):
     """ Create a session-level fprime test API

--- a/src/fprime_gds/common/testing_fw/pytest_integration.py
+++ b/src/fprime_gds/common/testing_fw/pytest_integration.py
@@ -52,11 +52,11 @@ def pytest_addoption(parser):
         action="store_true",
         help="Enable JUnitXML report generation to a specified location"
     )
-    # Add an option to specify a json config file that maps instances
+    # Add an option to specify a json config file that maps components
     parser.addoption(
         "--deployment-config",
         action="store",
-        help="Path to JSON configuration file for mapping deployment instances"
+        help="Path to JSON configuration file for mapping deployment components"
     )
 
 def pytest_configure(config):

--- a/src/fprime_gds/common/testing_fw/pytest_integration.py
+++ b/src/fprime_gds/common/testing_fw/pytest_integration.py
@@ -71,7 +71,7 @@ def pytest_configure(config):
 
     # Get the file path to the deployment configuration file
     if config.getoption("--deployment-config"):
-        config.option.deployment_config = config.getoption("--deployment-config")
+        deployment_config = config.getoption("--deployment-config")
 
 @pytest.fixture(scope='session')
 def fprime_test_api_session(request):
@@ -95,6 +95,7 @@ def fprime_test_api_session(request):
     pipeline_parser = StandardPipelineParser()
     pipeline = None
     api = None
+    deployment_config = None
     try:
         # Parse the command line arguments into a client connection
         arg_ns = pipeline_parser.handle_arguments(request.config.known_args_namespace, client=True)
@@ -102,12 +103,12 @@ def fprime_test_api_session(request):
         # Build a new pipeline with the parsed and processed arguments
         pipeline = pipeline_parser.pipeline_factory(arg_ns, pipeline)
 
-        # Add an attribute for deployment configuration file to pipeline
+        # Get deployment configuration from command line arguments
         if request.config.option.deployment_config:
-            pipeline.deployment_config = request.config.option.deployment_config
+            deployment_config = request.config.option.deployment_config
 
         # Build and set up the integration test api
-        api = IntegrationTestAPI(pipeline, arg_ns.logs)
+        api = IntegrationTestAPI(pipeline, deployment_config, arg_ns.logs)
         api.setup()
 
         # Return the API. Note: the second call here-in will begin after the yield and clean-up after the test

--- a/src/fprime_gds/common/testing_fw/pytest_integration.py
+++ b/src/fprime_gds/common/testing_fw/pytest_integration.py
@@ -52,6 +52,12 @@ def pytest_addoption(parser):
         action="store_true",
         help="Enable JUnitXML report generation to a specified location"
     )
+    # Add an option to specify a json config file that maps instances
+    parser.addoption(
+        "--deployment-config",
+        action="store",
+        help="Path to JSON configuration file for mapping deployment instances"
+    )
 
 def pytest_configure(config):
     """ This is a hook to allow plugins and conftest files to perform initial configuration
@@ -62,6 +68,10 @@ def pytest_configure(config):
     # Create a JUnit XML report file to capture the test result in a specified location
     if config.getoption("--gen-junitxml"):
         config.option.xmlpath = Path(config.getoption("--logs")) / config.getoption("--junit-xml-file")
+
+    # Get the file path to the deployment configuration file
+    if config.getoption("--deployment-config"):
+        config.option.deployment_config = config.getoption("--deployment-config")
 
 @pytest.fixture(scope='session')
 def fprime_test_api_session(request):
@@ -91,6 +101,10 @@ def fprime_test_api_session(request):
 
         # Build a new pipeline with the parsed and processed arguments
         pipeline = pipeline_parser.pipeline_factory(arg_ns, pipeline)
+
+        # Add an attribute for deployment configuration file to pipeline
+        if request.config.option.deployment_config:
+            pipeline.deployment_config = request.config.option.deployment_config
 
         # Build and set up the integration test api
         api = IntegrationTestAPI(pipeline, arg_ns.logs)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| [3213](https://github.com/nasa/fprime/issues/3213) |
|**_Has Unit Tests (y/n)_**| N/A |
|**_Documentation Included (y/n)_**| Y |

---
## Change Description

Adding a feature to pytest to load a deployment configuration file with a list of deployment configurations. This configuration will list the instance names of F Prime components and the file path to parameter db.
 
- [x] component instance name: getCmdDispName()
- [x] file path to parameter db: getPrmDbFilename()

## Rationale

Component instance names can be different across different deployments. As we start developing InT scripts for each component, we'll need to implement them while being deployment agnostic. The InT scripts will utilize the configuration JSON file to know component's instance name and file path to parameter db. This is different than the current approach to hard-coding the instance name in the InT script.

## Testing/Review Recommendations

Ran pytest to check the loading of the the deployment configuration file using defined `--deployment-config` flag. Additional tests were performed using this feature as part of InT testing.

## Future Work

N/A
